### PR TITLE
Change AMD root export

### DIFF
--- a/templates/umd.hbs
+++ b/templates/umd.hbs
@@ -2,7 +2,7 @@
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
     define({{#if amdModuleId}}'{{amdModuleId}}', {{/if}}[{{{amdDependencies}}}], function ({{dependencies}}) {
-      return (root.returnExportsGlobal = factory({{dependencies}}));
+      return ({{#if objectToExport}}root['{{{objectToExport}}}'] = {{/if}}factory({{dependencies}}));
     });
   } else if (typeof exports === 'object') {
     // Node. Does not work with strict CommonJS, but


### PR DESCRIPTION
Use existing `objectToExport` instead of hardcoded value `returnExportsGlobal`
