### PR TITLE
Work on separator

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,27 +23,28 @@ inherits(UMD, EventEmitter);
 
 UMD.prototype._getDependencyDefaults = function _getDependencyDefaults() {
     var globalAlias = this.options.globalAlias;
+    var separator = this.options.separator || ',\n';
 
     return {
         amd: {
             indent: 6,
             items: [],
             prefix: '\"',
-            separator: ',\n',
+            separator: separator,
             suffix: '\"'
         },
         cjs: {
             indent: 6,
             items: [],
             prefix: 'require(\"',
-            separator: ',\n',
+            separator: separator,
             suffix: '\")'
         },
         global: {
             indent: 6,
             items: [],
             prefix: globalAlias ? globalAlias + '.' : '',
-            separator: ',\n',
+            separator: separator,
             suffix: ''
         }
     };
@@ -118,9 +119,12 @@ UMD.prototype.generate = function generate() {
         items = is.array(dependency) ? dependency : dependency.items || deps;
         prefix = dependency.prefix || '';
         separator = dependency.separator || ', ';
+        // add dependency indent only if separator include a line feed
+        if (separator.match(/\r?\n/g)) {
+          separator += dependencyIndent;
+        }
         suffix = dependency.suffix || '';
-        ctx[dependencyType + 'Dependencies'] = items.map(UMD.wrap(prefix, suffix)).join(separator +
-            dependencyIndent);
+        ctx[dependencyType + 'Dependencies'] = items.map(UMD.wrap(prefix, suffix)).join(separator);
     }
 
     ctx.dependencies = (depsOptions.args || deps).join(', ');


### PR DESCRIPTION
- add a separator option
- indent dependency only if separator contains a linefeed

The idea is to be able to customize the output, in my case using umd template,  from : 

```javascript 
  if (typeof define === 'function' && define.amd) {
    define(["marionette",
      "underscore"], function (Marionette, _) {
      return (root['State'] = factory(Marionette, _));
    });
  } else if (typeof exports === 'object') {
    // Node. Does not work with strict CommonJS, but
    // only CommonJS-like enviroments that support module.exports,
    // like Node.
    module.exports = factory(require("marionette"),
      require("underscore"));
  } else {
    root['State'] = factory(Marionette,
      _);
  }
```

to :
```javascript
  if (typeof define === 'function' && define.amd) {
    define(["marionette",
      "underscore"], function (Marionette, _) {
      return (root['State'] = factory(Marionette, _));
    });
  } else if (typeof exports === 'object') {
    // Node. Does not work with strict CommonJS, but
    // only CommonJS-like enviroments that support module.exports,
    // like Node.
    module.exports = factory(require("marionette"), require("underscore"));
  } else {
    root['State'] = factory(Marionette, _);
  }
```
