### PR TITLE
Tests for dependencies

### DIFF
--- a/tests/amd-with-deps-and-alias.js
+++ b/tests/amd-with-deps-and-alias.js
@@ -1,0 +1,36 @@
+'use strict';
+var assert = require('assert');
+var fs = require('fs');
+var path = require('path');
+var umdify = require('../');
+var utils = require('./utils');
+
+module.exports = function() {
+    var amdLoaderPath = path.join(__dirname, 'amd_loader.js');
+    var code = fs.readFileSync(amdLoaderPath, {
+        encoding: 'utf-8'
+    });
+
+    utils.read(function(data) {
+        code += umdify(data, {
+            amdModuleId: 'test',
+            globalAlias: 'test'
+        });
+
+        utils.read(function(data) {
+            code += umdify(data, {
+                amdModuleId: 'testDeps',
+                globalAlias: 'testDeps',
+                deps: {
+                    'default': [{'test': 'alias'}]
+                }
+            });
+            code += '\nrequire([\'test\'], function(test) {test();});';
+
+            utils.runInPhantom(code, function(msg) {
+                console.log('amd-with-deps ok');
+                assert.equal(msg, 'executed');
+            });
+        }, 'with-deps-and-alias.js');
+    }, 'browser.js');
+}

--- a/tests/amd-with-deps.js
+++ b/tests/amd-with-deps.js
@@ -1,0 +1,38 @@
+'use strict';
+var assert = require('assert');
+var fs = require('fs');
+var path = require('path');
+var umdify = require('../');
+var utils = require('./utils');
+
+module.exports = function() {
+    var amdLoaderPath = path.join(__dirname, 'amd_loader.js');
+    var code = fs.readFileSync(amdLoaderPath, {
+        encoding: 'utf-8'
+    });
+
+    utils.read(function(data) {
+        code += umdify(data, {
+            amdModuleId: 'test',
+            globalAlias: 'test'
+        });
+
+        utils.read(function(data) {
+            code += umdify(data, {
+                amdModuleId: 'testDeps',
+                globalAlias: 'testDeps',
+                deps: {
+                    'default': ['test']
+                }
+            });
+            code += '\nrequire([\'testDeps\'], function(testDeps) {/* testDeps(); */});';
+            console.log('CODE:\n' + code);
+/*
+            utils.runInPhantom(code, function(msg) {
+                console.log('amd-with-deps ok');
+                assert.equal(msg, 'executed');
+            });
+*/
+        }, 'with-deps.js');
+    }, 'browser.js');
+}

--- a/tests/amd-with-deps.js
+++ b/tests/amd-with-deps.js
@@ -26,13 +26,11 @@ module.exports = function() {
                 }
             });
             code += '\nrequire([\'testDeps\'], function(testDeps) {/* testDeps(); */});';
-            console.log('CODE:\n' + code);
-/*
+
             utils.runInPhantom(code, function(msg) {
                 console.log('amd-with-deps ok');
                 assert.equal(msg, 'executed');
             });
-*/
         }, 'with-deps.js');
     }, 'browser.js');
 }

--- a/tests/browser-with-deps-and-alias.js
+++ b/tests/browser-with-deps-and-alias.js
@@ -1,0 +1,30 @@
+'use strict';
+var assert = require('assert');
+var umdify = require('../');
+var utils = require('./utils');
+
+var code;
+module.exports = function() {
+    utils.read(function(data) {
+        code = umdify(data, {
+            globalAlias: 'test',
+        });
+
+        utils.read(function(data) {
+            code += umdify(data, {
+                globalAlias: 'testDeps',
+                deps: {
+                    'default': [{'test':'alias'}]
+                }
+            });
+
+            code += '\nwindow.testDeps();';
+
+            utils.runInPhantom(code, function(msg) {
+                console.log('browser-with-deps-and-alias ok');
+                assert.equal(msg, 'executed');
+            });
+        }, 'with-deps-and-alias.js');
+
+    }, 'browser.js');
+}

--- a/tests/browser-with-deps.js
+++ b/tests/browser-with-deps.js
@@ -1,0 +1,30 @@
+'use strict';
+var assert = require('assert');
+var umdify = require('../');
+var utils = require('./utils');
+
+var code;
+module.exports = function() {
+    utils.read(function(data) {
+        code = umdify(data, {
+            globalAlias: 'test',
+        });
+
+        utils.read(function(data) {
+            code += umdify(data, {
+                globalAlias: 'testDeps',
+                deps: {
+                    'default': ['test']
+                }
+            });
+
+            code += '\nwindow.testDeps();';
+
+            utils.runInPhantom(code, function(msg) {
+                console.log('browser-with-deps ok');
+                assert.equal(msg, 'executed');
+            });
+        }, 'with-deps.js');
+
+    }, 'browser.js');
+}

--- a/tests/data/with-deps-and-alias.js
+++ b/tests/data/with-deps-and-alias.js
@@ -1,0 +1,5 @@
+return function testDeps() {
+    alias();
+
+    window.close();
+};

--- a/tests/data/with-deps.js
+++ b/tests/data/with-deps.js
@@ -1,0 +1,5 @@
+return function testDeps() {
+    test();
+
+    window.close();
+};

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,17 +1,19 @@
 'use strict';
 var amd = require('./amd');
-var amdWithDeps = require('./amd-with-deps');
+// var amdWithDeps = require('./amd-with-deps');
 var browser = require('./browser');
 var browserWithDeps = require('./browser-with-deps');
+var browserWithDepsAndAlias = require('./browser-with-deps-and-alias');
 var cjs = require('./cjs');
 
 tests();
 
 function tests() {
     amd();
-    amdWithDeps();
+//    amdWithDeps();
     browser();
     browserWithDeps();
+    browserWithDepsAndAlias();
     cjs();
 }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,13 +1,17 @@
 'use strict';
 var amd = require('./amd');
+var amdWithDeps = require('./amd-with-deps');
 var browser = require('./browser');
+var browserWithDeps = require('./browser-with-deps');
 var cjs = require('./cjs');
 
 tests();
 
 function tests() {
     amd();
+    amdWithDeps();
     browser();
+    browserWithDeps();
     cjs();
 }
 


### PR DESCRIPTION
I have added these tests:

**browser-with-deps**
This tests `umdify`ing a file that needs a dependency and then running in the browser

**amd-with-deps**
This tests `umdify`ing a file that needs a dependency and then running in an AMD loader
*This test is diabled as it does not work correctly with the current implementation of `define`*

**browser-with-deps-and-alias** 
This tests `umdify`ing a file that needs a dependency and uses that dependency through an alias (e.g. dependency = `'jquery'`, alias = `'$'`) then running in the browser.

**amd-with-deps-and-alias**
This tests `umdify`ing a file that needs a dependency and uses that dependency through an alias (e.g. dependency = `'jquery'`, alias = `'$'`) then running in an AMD loader.
*This is a first attempt at the AMD version of the alias test, but since I did not get the `amd-with-deps` version running, this is untested.*

I have disabled the `amd-with-deps` test in `index.js` because it does not work and I have not even added the `amd-with-deps-and-alias` test to `index.js` for the same reason.

When running the tests with `node tests`, I get this output:

```sh
cjs ok
browser-with-deps ok
SyntaxError: Parse error []
amd ok
browser ok
```

The syntax error happens in `browser-with-deps-and-alias` and is the result of the syntax I am using to alias the dependency, which is not yet supported of course: 

```js
code += umdify(data, {
    globalAlias: 'testDeps',
    deps: {
        'default': [{'test':'alias'}]
    }
});
```

If I get rid of the invalid syntax:

```js
code += umdify(data, {
    globalAlias: 'testDeps',
    deps: {
        'default': ['test']
    }
});
```

The test fails because the code is expecting the alias:

```sh
cjs ok
browser-with-deps ok
amd ok
browser ok
ReferenceError: Can't find variable: alias [ { file: 'C:\\Users\\Frank\\AppData\\Local\\Temp\\tmp-7220MADKVk0LiG03.tmp',
    line: 42,
    function: 'testDeps' },
  { file: 'C:\\Users\\Frank\\AppData\\Local\\Temp\\tmp-7220MADKVk0LiG03.tmp',
    line: 50,
    function: '' } ]
```
