### PR TITLE
fix: syntax error when dependency name has a dash

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ UMD.prototype.generate = function generate() {
         suffix = dependency.suffix || '';
 
         ctx[dependencyType + 'Dependencies'] = {
-            normal: items,
+            normal: items.map(function(item){ return 'root["' + item + '"]'; }),
             params: convertToAlphabet(items),
             wrapped: items.map(wrap(prefix, suffix)).join(separator),
         };

--- a/tests/cjs.js
+++ b/tests/cjs.js
@@ -115,7 +115,7 @@ function useDefault() {
 
     assert(code.indexOf('define(["' + dep + '"]') >= 0);
     assert(code.indexOf('factory(require("' + dep + '"))') >= 0);
-    assert(code.indexOf('factory(' + dep + ')') >= 0);
+    assert(code.indexOf('factory(root["' + dep + '"])') >= 0);
 }
 
 function preserveDefault() {
@@ -129,7 +129,7 @@ function preserveDefault() {
 
     assert(code.indexOf('define(["baz","bar"], function (a0,b1) {') >= 0);
     assert(code.indexOf('factory(require("' + dep + '"))') >= 0);
-    assert(code.indexOf('factory(' + dep + ')') >= 0);
+    assert(code.indexOf('factory(root["' + dep + '"])') >= 0);
 }
 
 function convertParametersToAlphabet() {


### PR DESCRIPTION
The generated output can have a syntax error when it is defining the
variable in the global scope and the dependency name has a dash, or
other syntactically incorrect expression.