### PR TITLE
Improving checks for module.exports support

### DIFF
--- a/templates/returnExportsGlobal.hbs
+++ b/templates/returnExportsGlobal.hbs
@@ -22,7 +22,7 @@
         define({{#if amdModuleId}}'{{amdModuleId}}', {{/if}}[{{{amdDependencies.wrapped}}}], function ({{dependencies}}) {
             return ({{#if globalAlias}} root['{{{globalAlias}}}'] = {{/if}}factory({{dependencies}}));
         });
-    } else if (typeof exports === 'object') {
+    } else if (typeof module === 'object' && module.exports) {
         {{!--
             Node. Does not work with strict CommonJS, but
             only CommonJS-like enviroments that support module.exports,
@@ -33,7 +33,7 @@
 
         {{! FIX FOR BROWSERIFY: Set global alias if we in browserify. }}
         {{#if globalAlias}}
-          if(typeof window !== "undefined"){
+          if(typeof window !== 'undefined'){
               window['{{{globalAlias}}}'] = module_exports;
           }
         {{/if}}

--- a/templates/umd+rails.hbs
+++ b/templates/umd+rails.hbs
@@ -2,12 +2,12 @@
 
 (function(factory) {
   /* jshint undef: true */
-  if (typeof define === "function" && define.amd) {
+  if (typeof define === 'function' && define.amd) {
     define({{#if amdModuleId}}'{{amdModuleId}}', {{/if}}[
       {{{amdDependencies.wrapped}}}
     ], factory);
   }
-  else if (typeof module !== "undefined" && module.exports) {
+  else if (typeof module === 'object' && module.exports) {
     module.exports = factory(
       {{{cjsDependencies.wrapped}}});
   }

--- a/templates/umd.hbs
+++ b/templates/umd.hbs
@@ -4,7 +4,7 @@
     define({{#if amdModuleId}}'{{amdModuleId}}', {{/if}}[{{{amdDependencies.wrapped}}}], function ({{{amdDependencies.params}}}) {
       return ({{#if objectToExport}}root['{{{objectToExport}}}'] = {{/if}}factory({{{amdDependencies.params}}}));
     });
-  } else if (typeof exports === 'object') {
+  } else if (typeof module === 'object' && module.exports) {
     // Node. Does not work with strict CommonJS, but
     // only CommonJS-like environments that support module.exports,
     // like Node.

--- a/templates/unit.hbs
+++ b/templates/unit.hbs
@@ -1,6 +1,6 @@
 {{! UMD template that can be useful to wrap standalone CommonJS/Node modules}}
 (function(root, factory) {
-    if(typeof exports === 'object') {
+    if(typeof module === 'object' && module.exports) {
         module.exports = factory({{#if cjsDependencies.wrapped}}{{{cjsDependencies.wrapped}}}, {{/if}}require, exports, module);
     }
     else if(typeof define === 'function' && define.amd) {


### PR DESCRIPTION
Current check for module.exports isn't sufficient IMO. Updating to align with checks in other libraries.