### PR TITLE
define root in strict mode for browsers

### DIFF
--- a/templates/returnExportsGlobal.hbs
+++ b/templates/returnExportsGlobal.hbs
@@ -17,6 +17,7 @@
 --}}
 
 (function (root, factory) {
+    if (root === undefined && window !== undefined) root = window;
     if (typeof define === 'function' && define.amd) {
         {{! AMD. Register as an anonymous module. }}
         define({{#if amdModuleId}}'{{amdModuleId}}', {{/if}}[{{{amdDependencies.wrapped}}}], function ({{dependencies}}) {

--- a/templates/umd.hbs
+++ b/templates/umd.hbs
@@ -1,4 +1,5 @@
 (function (root, factory) {
+  if (root === undefined && window !== undefined) root = window;
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module unless amdModuleId is set
     define({{#if amdModuleId}}'{{amdModuleId}}', {{/if}}[{{{amdDependencies.wrapped}}}], function ({{{amdDependencies.params}}}) {

--- a/templates/unit.hbs
+++ b/templates/unit.hbs
@@ -1,6 +1,7 @@
 {{! UMD template that can be useful to wrap standalone CommonJS/Node modules}}
 (function(root, factory) {
-    if(typeof module === 'object' && module.exports) {
+    if (root === undefined && window !== undefined) root = window;
+    if (typeof module === 'object' && module.exports) {
         module.exports = factory({{#if cjsDependencies.wrapped}}{{{cjsDependencies.wrapped}}}, {{/if}}require, exports, module);
     }
     else if(typeof define === 'function' && define.amd) {


### PR DESCRIPTION
Not sure if this is the right way but all templates did not solve my issue.

Related:
https://github.com/jonathantneal/svg4everybody/issues/111
https://github.com/jonathantneal/svg4everybody/issues/162

This provides a fix for #19 for environments in strict mode.