### PR TITLE
Use global alias in AMD like in other places

### DIFF
--- a/templates/umd.hbs
+++ b/templates/umd.hbs
@@ -3,7 +3,7 @@
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module unless amdModuleId is set
     define({{#if amdModuleId}}'{{amdModuleId}}', {{/if}}[{{{amdDependencies.wrapped}}}], function ({{{amdDependencies.params}}}) {
-      return ({{#if objectToExport}}root['{{{objectToExport}}}'] = {{/if}}factory({{{amdDependencies.params}}}));
+      return ({{#if globalAlias}}root['{{{globalAlias}}}'] = {{else}}{{#if objectToExport}}root['{{{objectToExport}}}'] = {{/if}}{{/if}}factory({{{amdDependencies.params}}}));
     });
   } else if (typeof module === 'object' && module.exports) {
     // Node. Does not work with strict CommonJS, but


### PR DESCRIPTION
Hi!

I found, that if `globalAlias` is defined the result for AMD does not take it into account and sets `objectToExport` to the global scope, if it is defined. In case, when both `objectToExport` and `globalAlias` are defined, we have like a two different refence names in global registers, depending what loading approach is going to be used.

Also I see that in other templates `globalAlias` is used everywhere, where the reference is going to be stored in a global scope:

* https://github.com/bebraw/libumd/blob/master/templates/returnExportsGlobal.hbs#L24
* https://github.com/bebraw/libumd/blob/master/templates/returnExportsGlobal.hbs#L43
* https://github.com/bebraw/libumd/blob/master/templates/unit.hbs#L14

except of this place:

* https://github.com/bebraw/libumd/blob/master/templates/umd.hbs#L6

Not sure why `globalAlias` was not taken into account (https://github.com/bebraw/libumd/commit/c82d67c108b25609dbd695a5f6c0dde1a56d7253), but, I think, this should be alligned to have the same behavior everywhere.

### Important

Please note, that this change can break someone if and only if someone is loading the library over AMD and then later, for some reasons, is referencing to the librarary from a global scope (not sure if someone doing this, but it is possible). With this change the name to the library in global scope will be different, than before, if author of some library is using both `objectToExport` and `globalAlias` by wrapping.

To allow to do a safe migration, I propose to increment the major version of this library, to indicate that something is not backward compatible to the previous versions. The same, should be done for https://github.com/bebraw/grunt-umd - update the major version for `libumd` there and increment the major version of it.